### PR TITLE
SST-3: Create script builder and first script

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Stream-SQL-TCK
-A test-compatability kit for implementations of streaming SQL
+A test-compatibility kit for implementations of streaming SQL
 Copyright (C) 2018-2018 The authors
 
 ===============================================================================

--- a/README.md
+++ b/README.md
@@ -50,6 +50,47 @@ and reviewing other people's proposed changes.
 We would especially like contributions of documentation (for example, describing
 streaming SQL's intent and semantics on this site) and richer test cases.
 
+## Scripts
+
+Each test is called a *script* and consists of:
+
+* One or more stream definitions
+* A query (or possibly several) based on those streams
+* Records to insert into the stream(s) at particular times
+* Expected observations, such as which records should be emitted from
+  the query at particular times
+
+A script is defined using a Java API. Here is a simple example:
+
+```java
+import net.hydromatic.streamsqltck.Script;
+
+public class ScriptSuite {
+  public Script selectWhere() {
+    return Script.builder()
+        .definitions()
+        .stream("Orders")
+        .timestamp("rowtime").notNull()
+        .integer("orderId").notNull()
+        .varchar("product", 20).notNull()
+        .end() // stream "Orders"
+        .end() // definitions
+        .query("Q", "select orderId from Orders where product = 'milk'")
+        .input()
+        .insert("ORDERS", 0, 100, "beer")
+        .insert("ORDERS", 1, 101, "milk")
+        .end() // input
+        .expect()
+        .row("Q", 101)
+        .end() // expect
+        .build();
+  }
+}
+```
+
+There are more examples in
+[Basic.java](src/main/java/net/hydromatic/streamsqltck/basic/Basic.java).
+
 ## Get Stream-SQL-TCK
 
 If you are the author of a streaming engine, use the TCK in your test suite!
@@ -71,7 +112,7 @@ Get Stream-SQL-TCK from Maven Central:
 
 ### Download and build
 
-You need Java (1.8 or higher; 1.9 preferred), git and maven (3.5.2 or higher).
+You need Java (8 or higher; 9 preferred), git and maven (3.5.2 or higher).
 
 ```bash
 $ git clone git://github.com/Stream-SQL-TCK/Stream-SQL-TCK.git stream-sql-tck
@@ -82,7 +123,6 @@ $ mvn compile
 ## More information
 
 * License: <a href="LICENSE">Apache Software License, Version 2.0</a>
-* Author: Julian Hyde
 * Source code: http://github.com/Stream-SQL-TCK/Stream-SQL-TCK
 * Developers list:
   <a href="mailto:dev@calcite.apache.org">dev at calcite.apache.org</a>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <top.dir>${project.basedir}</top.dir>
+
+    <!-- We support guava as old as 19.0 but prefer more recent versions. -->
+    <guava.version>19.0</guava.version>
+    <junit.version>4.12</junit.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
   </properties>
 
   <distributionManagement/>
@@ -64,9 +70,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -79,7 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven-enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -121,6 +132,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
         <executions>
           <execution>
             <id>validate</id>

--- a/src/main/config/checkstyle/checker.xml
+++ b/src/main/config/checkstyle/checker.xml
@@ -82,10 +82,6 @@
     </module>
       <!-- Switch statements should be complete and with independent cases -->
     <module name="FallThrough"/>
-    <!-- For hadoop_yarn profile, some YARN exceptions aren't loading in checkstyle -->
-    <module name="RedundantThrows">
-        <property name="suppressLoadErrors" value="true" />
-    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
       <!-- Only one statement per line allowed -->
@@ -130,9 +126,7 @@
       <property name="checkFirstSentence" value="false"/>
     </module>
       <!-- Must have class / interface header comments -->
-<!-- todo: enable
     <module name="JavadocType"/>
--->
 
     <!-- Miscellaneous other checks (tree walker).     -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->

--- a/src/main/java/net/hydromatic/streamsqltck/Column.java
+++ b/src/main/java/net/hydromatic/streamsqltck/Column.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.hydromatic.streamsqltck;
+
+import com.google.common.base.Preconditions;
+
+/** Definition of a Column in a Stream.
+ *
+ * <p>It is immutable. */
+public class Column {
+  /** Column name. */
+  public final String name;
+
+  /** Column type. Generally one of the standard SQL types: BIGINT, INTEGER,
+   * SMALLINT, TINYINT, DOUBLE, REAL, DECIMAL, BOOLEAN, CHAR, VARCHAR, BINARY,
+   * VARBINARY. */
+  public final String type;
+
+  /** Precision of type; may be null. */
+  public final Integer precision;
+
+  /** Scale of type; may be null. */
+  public final Integer scale;
+
+  /** Whether column allows NULL values. */
+  public final boolean nullable;
+
+  /** Creates a Column. */
+  Column(String name, String type, Integer precision, Integer scale,
+      boolean nullable) {
+    this.name = Preconditions.checkNotNull(name);
+    this.type = Preconditions.checkNotNull(type);
+    this.precision = precision;
+    this.scale = scale;
+    this.nullable = nullable;
+  }
+
+  /** Returns a copy of this column with a given value for
+   * {@link #nullable}. */
+  Column withNullable(boolean nullable) {
+    return new Column(name, type, precision, scale, nullable);
+  }
+}
+
+// End Column.java

--- a/src/main/java/net/hydromatic/streamsqltck/Insert.java
+++ b/src/main/java/net/hydromatic/streamsqltck/Insert.java
@@ -16,13 +16,23 @@
  */
 package net.hydromatic.streamsqltck;
 
-/** The main class. */
-public class Main {
-  private Main() {}
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
-  public static void main(String[] args) {
-    System.out.println("Hello, world!");
+import java.util.List;
+
+/** Command to insert a record into a stream.
+ *
+ * <p>It is immutable, and is generally created via {@link ScriptBuilder}. */
+public class Insert {
+  public final String name;
+  public final List<Object> values;
+
+  /** Creates an Insert. */
+  Insert(String name, Iterable<Object> values) {
+    this.name = Preconditions.checkNotNull(name);
+    this.values = ImmutableList.copyOf(values);
   }
 }
 
-// End Main.java
+// End Insert.java

--- a/src/main/java/net/hydromatic/streamsqltck/Script.java
+++ b/src/main/java/net/hydromatic/streamsqltck/Script.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.hydromatic.streamsqltck;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+/** A test script.
+ *
+ * <p>Consists of a query, input data, and expected output data.
+ *
+ * <p>It is immutable, and cannot be created from outside this package.
+ * End-users should use a {@link ScriptBuilder}.
+ */
+public class Script {
+  public final Map<String, Stream> definitions;
+  public final Map<String, String> queries;
+  public final List<Insert> inputs;
+  public final Map<String, List> expectations;
+
+  /** Creates a Script.
+   *
+   * <p>End users typically use {@link ScriptBuilder#build}.
+   *
+   * @param definitions Definitions of streams
+   * @param queries Queries to be run by the script
+   * @param inputs Input records
+   * @param expectations Expected output records
+   */
+  Script(Map<String, Stream> definitions, Map<String, String> queries,
+      List<Insert> inputs, Map<String, List> expectations) {
+    this.definitions = ImmutableMap.copyOf(definitions);
+    this.queries = ImmutableMap.copyOf(queries);
+    this.inputs = ImmutableList.copyOf(inputs);
+    this.expectations = ImmutableMap.copyOf(expectations);
+  }
+
+  /** Creates a builder that you can use to create a Script. */
+  public static ScriptBuilder builder() {
+    return new ScriptBuilder();
+  }
+}
+
+// End Script.java

--- a/src/main/java/net/hydromatic/streamsqltck/ScriptBuilder.java
+++ b/src/main/java/net/hydromatic/streamsqltck/ScriptBuilder.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.hydromatic.streamsqltck;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/** Builder for {@link Script}.
+ *
+ * <p>Example use:
+ *
+ * <blockquote>
+ *     Script s =
+ *       Script.builder()
+ *         .definitions()
+ *         .stream("ORDERS",
+ *           "(TIMESTAMP rowtime, INT orderId, VARCHAR(20) product)")
+ *         .end()
+ *         .query("Q", "select orderId from orders where product = 'milk'")
+ *         .input()
+ *         .insert("ORDERS", 0, 100, "beer")
+ *         .insert("ORDERS", 1, 101, "milk")
+ *         .end()
+ *         .expect()
+ *         .row("Q", 101)
+ *         .end()
+ *         .build();
+ * </blockquote>. */
+public class ScriptBuilder {
+  private final Map<String, Stream> definitions = new LinkedHashMap<>();
+  private final Map<String, String> queries = new LinkedHashMap<>();
+  private final List<Insert> inputs = new ArrayList<>();
+  private final Map<String, List> expectations = new LinkedHashMap<>();
+
+  ScriptBuilder() {}
+
+  /** Starts building the definitions of this script. You can add multiple
+   * {@link DefinitionsBuilder#stream(String)} elements, followed
+   * by {@link DefinitionsBuilder#end end}. */
+  public DefinitionsBuilder definitions() {
+    return new DefinitionsBuilder();
+  }
+
+  /** Adds a query to this script. Every query has a name. */
+  public ScriptBuilder query(String name, String sql) {
+    Preconditions.checkNotNull(name);
+    Preconditions.checkNotNull(sql);
+    if (queries.put(name, sql) != null) {
+      throw new IllegalArgumentException("duplicate query " + name);
+    }
+    return this;
+  }
+
+  /** Starts building the expectations of this script. You can add multiple
+   * {@link ExpectationsBuilder#row row} elements,
+   * followed by {@link ExpectationsBuilder#end end}. */
+  public ExpectationsBuilder expect() {
+    return new ExpectationsBuilder();
+  }
+
+  public Script build() {
+    return new Script(definitions, queries, inputs, expectations);
+  }
+
+  /** Starts building the inputs of this script. You can add multiple
+   * {@link InputsBuilder#insert insert} elements,
+   * followed by {@link InputsBuilder#end end}. */
+  public InputsBuilder input() {
+    return new InputsBuilder();
+  }
+
+  /** Builds the definitions section of a script. */
+  public class DefinitionsBuilder {
+    private DefinitionsBuilder() {}
+
+    public StreamBuilder stream(String name) {
+      Preconditions.checkNotNull(name);
+      return new StreamBuilder(this, name);
+    }
+
+    /** Ends the definitions section and returns the parent ScriptBuilder. */
+    public ScriptBuilder end() {
+      return ScriptBuilder.this;
+    }
+
+    /** Applies this DefinitionsBuilder to an action. */
+    public DefinitionsBuilder apply(Consumer<DefinitionsBuilder> o) {
+      o.accept(this);
+      return this;
+    }
+
+    private void addStream(String streamName, List<Column> columns) {
+      final Stream stream = new Stream(streamName, columns);
+      if (definitions.put(streamName, stream) != null) {
+        throw new IllegalArgumentException("duplicate stream " + streamName);
+      }
+    }
+  }
+
+  /** Builds a stream definition.
+   *
+   * <p>Created via {@link DefinitionsBuilder#stream}. */
+  public class StreamBuilder {
+    private DefinitionsBuilder definitionsBuilder;
+    final String streamName;
+    final List<Column> columns = new ArrayList<>();
+
+    StreamBuilder(DefinitionsBuilder definitionsBuilder, String streamName) {
+      this.definitionsBuilder = definitionsBuilder;
+      this.streamName = streamName;
+    }
+
+    /** Finishes the definition of this stream, registers it, and returns the
+     * parent {@link DefinitionsBuilder}. */
+    public DefinitionsBuilder end() {
+      definitionsBuilder.addStream(streamName, columns);
+      return definitionsBuilder;
+    }
+
+    /** Adds a column. */
+    public StreamBuilder column(String name, String type, Integer precision,
+        Integer scale, boolean nullable) {
+      columns.add(new Column(name, type, precision, scale, nullable));
+      return this;
+    }
+
+    /** Changes the nullability of the previous column added.
+     *
+     * @throws IndexOutOfBoundsException if there was no previous column */
+    public StreamBuilder notNull() {
+      final int index = columns.size() - 1;
+      final Column column = columns.get(index);
+      columns.set(index, column.withNullable(false));
+      return this;
+    }
+
+    /** Adds a BOOLEAN column. */
+    public StreamBuilder boolean_(String columnName) {
+      return column(columnName, "BOOLEAN", null, null, true);
+    }
+
+    /** Adds a CHAR(precision) column. */
+    public StreamBuilder char_(String columnName, int precision) {
+      return column(columnName, "CHAR", precision, null, true);
+    }
+
+    /** Adds a VARCHAR(precision) column. */
+    public StreamBuilder varchar(String columnName, int precision) {
+      return column(columnName, "VARCHAR", precision, null, true);
+    }
+
+    /** Adds a BINARY(precision) column. */
+    public StreamBuilder binary(String columnName, int precision) {
+      return column(columnName, "BINARY", precision, null, true);
+    }
+
+    /** Adds a VARBINARY(precision) column. */
+    public StreamBuilder varbinary(String columnName, int precision) {
+      return column(columnName, "VARBINARY", precision, null, true);
+    }
+
+    /** Adds a BIGINT column. */
+    public StreamBuilder bigint(String columnName) {
+      return column(columnName, "BIGINT", null, null, true);
+    }
+
+    /** Adds an INTEGER column. */
+    public StreamBuilder integer(String columnName) {
+      return column(columnName, "INTEGER", null, null, true);
+    }
+
+    /** Adds a SMALLINT column. */
+    public StreamBuilder smallint(String columnName) {
+      return column(columnName, "SMALLINT", null, null, true);
+    }
+
+    /** Adds a TINYINT column. */
+    public StreamBuilder tinyint(String columnName) {
+      return column(columnName, "TINYINT", null, null, true);
+    }
+
+    /** Adds a DOUBLE column. */
+    public StreamBuilder double_(String columnName) {
+      return column(columnName, "DOUBLE", null, null, true);
+    }
+
+    /** Adds a REAL column. */
+    public StreamBuilder real(String columnName) {
+      return column(columnName, "REAL", null, null, true);
+    }
+
+    /** Adds a DECIMAL(precision, scale) column. */
+    public StreamBuilder real(String columnName, int precision, int scale) {
+      return column(columnName, "DECIMAL", precision, scale, true);
+    }
+
+    /** Adds a DATE column. */
+    public StreamBuilder date(String columnName) {
+      return column(columnName, "DATE", null, null, true);
+    }
+
+    /** Adds a TIMESTAMP column. */
+    public StreamBuilder timestamp(String columnName) {
+      return column(columnName, "TIMESTAMP", null, null, true);
+    }
+
+    /** Adds a TIMESTAMP column with scale. */
+    public StreamBuilder timestamp(String columnName, int scale) {
+      return column(columnName, "TIMESTAMP", null, scale, true);
+    }
+
+    /** Adds a TIME column. */
+    public StreamBuilder time(String columnName) {
+      return column(columnName, "TIME", null, null, true);
+    }
+
+    /** Adds a TIME column with scale. */
+    public StreamBuilder time(String columnName, int scale) {
+      return column(columnName, "TIME", null, scale, true);
+    }
+  }
+
+  /** Builds the inputs section of a script. */
+  public class InputsBuilder {
+    private InputsBuilder() {}
+
+    public InputsBuilder insert(String streamName, Object... values) {
+      Preconditions.checkNotNull(streamName);
+      if (!definitions.containsKey(streamName)) {
+        throw new IllegalArgumentException("unknown target " + streamName
+            + "; must occur in the definitions");
+      }
+      inputs.add(new Insert(streamName, Arrays.asList(values)));
+      return this;
+    }
+
+    public InputsBuilder apply(Consumer<InputsBuilder> action) {
+      action.accept(this);
+      return this;
+    }
+
+    /** Ends the inputs section and returns the parent ScriptBuilder. */
+    public ScriptBuilder end() {
+      return ScriptBuilder.this;
+    }
+  }
+
+  /** Builds the expectations section of a script. */
+  public class ExpectationsBuilder {
+    private ExpectationsBuilder() {}
+
+    public ExpectationsBuilder row(String queryName, Object... values) {
+      Preconditions.checkNotNull(queryName);
+      Preconditions.checkNotNull(values);
+      if (!queries.containsKey(queryName)) {
+        throw new IllegalArgumentException("unknown query " + queryName);
+      }
+      expectations.put(queryName, ImmutableList.copyOf(values));
+      return this;
+    }
+
+    /** Ends the expectations section and returns the parent ScriptBuilder. */
+    public ScriptBuilder end() {
+      return ScriptBuilder.this;
+    }
+
+    public ExpectationsBuilder apply(Consumer<ExpectationsBuilder> action) {
+      action.accept(this);
+      return this;
+    }
+  }
+
+}
+
+// End ScriptBuilder.java

--- a/src/main/java/net/hydromatic/streamsqltck/Stream.java
+++ b/src/main/java/net/hydromatic/streamsqltck/Stream.java
@@ -1,8 +1,3 @@
-<?xml version="1.0"?>
-<!DOCTYPE suppressions PUBLIC
-        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
-<!--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,15 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
--->
-<suppressions>
-  <!-- Suppress checks on generated files. -->
-  <suppress checks=".*" files=".*[/\\]target[/\\]maven-archiver[/\\]pom.properties"/>
-  <suppress checks=".*" files="git.properties"/>
-  <suppress checks=".*" files="release.properties"/>
-  <suppress checks=".*" files="LICENSE"/>
-  <suppress checks=".*" files="NOTICE"/>
+package net.hydromatic.streamsqltck;
 
-  <!-- Suppress JavadocPackage in the test packages -->
-  <suppress checks="JavadocPackage" files="src[/\\]test[/\\]java[/\\]"/>
-</suppressions>
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/** Stream definition. */
+public class Stream {
+  public final String name;
+  public final List<Column> columns;
+
+  /** Create via {@link net.hydromatic.streamsqltck.ScriptBuilder}. */
+  Stream(String name, List<Column> columns) {
+    this.name = Preconditions.checkNotNull(name);
+    this.columns = ImmutableList.copyOf(columns);
+  }
+}
+
+// End Stream.java

--- a/src/main/java/net/hydromatic/streamsqltck/basic/Basic.java
+++ b/src/main/java/net/hydromatic/streamsqltck/basic/Basic.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.hydromatic.streamsqltck.basic;
+
+import net.hydromatic.streamsqltck.Script;
+import net.hydromatic.streamsqltck.ScriptBuilder;
+
+/** A collection of scripts that test basic streaming SQL functionality. */
+public class Basic {
+  public Script select() {
+    return Script.builder()
+        .definitions()
+        .apply(Basic::defineOrders)
+        .end()
+        .query("Q", "select * from Orders")
+        .input()
+        .insert("ORDERS", 0, 100, "beer")
+        .insert("ORDERS", 1, 101, "milk")
+        .end()
+        .expect()
+        .row("Q", 0, 100, "beer")
+        .row("Q", 0, 101, "milk")
+        .end()
+        .build();
+  }
+
+  public Script selectWhere() {
+    return Script.builder()
+        .definitions()
+        .apply(Basic::defineOrders)
+        .end()
+        .query("Q", "select orderId from orders where product = 'milk'")
+        .input()
+        .insert("ORDERS", 0, 100, "beer")
+        .insert("ORDERS", 1, 101, "milk")
+        .end()
+        .expect()
+        .row("Q", 101)
+        .end()
+        .build();
+  }
+
+  private static void defineOrders(ScriptBuilder.DefinitionsBuilder b) {
+    b.stream("Orders")
+        .timestamp("rowtime").notNull()
+        .integer("orderId").notNull()
+        .varchar("product", 20).notNull()
+        .end();
+  }
+}
+
+// End Basic.java

--- a/src/main/java/net/hydromatic/streamsqltck/basic/package-info.java
+++ b/src/main/java/net/hydromatic/streamsqltck/basic/package-info.java
@@ -1,8 +1,3 @@
-<?xml version="1.0"?>
-<!DOCTYPE suppressions PUBLIC
-        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
-<!--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,15 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
--->
-<suppressions>
-  <!-- Suppress checks on generated files. -->
-  <suppress checks=".*" files=".*[/\\]target[/\\]maven-archiver[/\\]pom.properties"/>
-  <suppress checks=".*" files="git.properties"/>
-  <suppress checks=".*" files="release.properties"/>
-  <suppress checks=".*" files="LICENSE"/>
-  <suppress checks=".*" files="NOTICE"/>
 
-  <!-- Suppress JavadocPackage in the test packages -->
-  <suppress checks="JavadocPackage" files="src[/\\]test[/\\]java[/\\]"/>
-</suppressions>
+/** Scripts that test basic streaming SQL functionality. */
+package net.hydromatic.streamsqltck.basic;
+
+// End package-info.java

--- a/src/test/java/net/hydromatic/streamsqltck/ScriptBuilderTest.java
+++ b/src/test/java/net/hydromatic/streamsqltck/ScriptBuilderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.hydromatic.streamsqltck;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/** Unit tests for {@link net.hydromatic.streamsqltck.ScriptBuilder}. */
+public class ScriptBuilderTest {
+  @Test public void testDuplicateStreamNames() {
+    try {
+      Script.builder()
+          .definitions()
+          .stream("S0")
+          .integer("x")
+          .end()
+          .stream("S1")
+          .integer("x")
+          .end()
+          .stream("S2")
+          .boolean_("b")
+          .end()
+          .stream("S1")
+          .integer("x")
+          .end();
+      fail("expected throw");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("duplicate stream S1"));
+    }
+  }
+
+  @Test public void testQueryNames() {
+    try {
+      Script.builder()
+          .definitions()
+          .stream("S1")
+          .integer("x")
+          .end()
+          .end()
+          .query("Q1", "values 1")
+          .query("Q2", "values 2")
+          .query("Q1", "values 3");
+      fail("expected throw");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("duplicate query Q1"));
+    }
+  }
+
+  /** Tests a script whose definitions section is empty. */
+  @Test public void testNoDefinitions() {
+    final Script script = Script.builder()
+        .definitions()
+        .end()
+        .query("Q", "values 1")
+        .expect()
+        .end()
+        .build();
+    assertThat(script.definitions.isEmpty(), is(true));
+  }
+
+  /** Tests {@link net.hydromatic.streamsqltck.ScriptBuilder.DefinitionsBuilder#apply}
+   * and similar. */
+  @Test public void testApply() {
+    final Script script = Script.builder()
+        .definitions()
+        .apply(ScriptBuilderTest::defineOrders)
+        .end()
+        .query("Q", "values 1")
+        .input()
+        .apply(ScriptBuilderTest::defineInput)
+        .end()
+        .expect()
+        .apply(ScriptBuilderTest::defineOutput)
+        .end()
+        .build();
+    assertThat(script.definitions.containsKey("ORDERS"), is(true));
+    final Stream ordersStream = script.definitions.get("ORDERS");
+    assertThat(ordersStream.name, is("ORDERS"));
+    assertThat(ordersStream.columns.size(), is(3));
+    assertThat(ordersStream.columns.get(0).type, is("TIMESTAMP"));
+    assertThat(ordersStream.columns.get(0).precision, CoreMatchers.nullValue());
+    assertThat(ordersStream.columns.get(0).scale, CoreMatchers.nullValue());
+    assertThat(ordersStream.columns.get(0).nullable, is(false));
+    assertThat(ordersStream.columns.get(2).type, is("VARCHAR"));
+    assertThat(ordersStream.columns.get(2).precision, is(1000));
+    assertThat(ordersStream.columns.get(2).scale, CoreMatchers.nullValue());
+    assertThat(ordersStream.columns.get(2).nullable, is(true));
+    assertThat(script.queries.containsKey("Q"), is(true));
+    assertThat(script.inputs.size(), is(2));
+    assertThat(script.inputs.get(0).name, is("ORDERS"));
+    assertThat(script.inputs.get(0).values.size(), is(3));
+    assertThat(script.inputs.get(0).values.get(0), is(0));
+    assertThat(script.inputs.get(0).values.get(1), is(100));
+    assertThat(script.inputs.get(0).values.get(2), is("beer"));
+    assertThat(script.expectations.containsKey("Q"), is(true));
+  }
+
+  private static void defineOrders(ScriptBuilder.DefinitionsBuilder b) {
+    b.stream("ORDERS")
+        .timestamp("rowtime").notNull()
+        .integer("orderId").notNull()
+        .varchar("comments", 1000)
+        .end();
+  }
+
+  private static void defineOutput(ScriptBuilder.ExpectationsBuilder b) {
+    b.row("Q");
+  }
+
+  private static void defineInput(ScriptBuilder.InputsBuilder b) {
+    b.insert("ORDERS", 0, 100, "beer");
+    b.insert("ORDERS", 1, 101, "milk");
+  }
+}
+
+// End ScriptBuilderTest.java


### PR DESCRIPTION
This is how I think we can build scripts programmatically using a builder. A first script illustrates.

It doesn't rule out building scripts from other languages at a later date, or creating a DSL for scripts.

Note that I called them "scripts" rather than "tests" because I didn't want to tie them exclusively to test frameworks and the "test" part of the maven lifecycle.